### PR TITLE
Unit tests

### DIFF
--- a/src/WorkoutTracker.Api/Data/ApplicationDbContext.cs
+++ b/src/WorkoutTracker.Api/Data/ApplicationDbContext.cs
@@ -34,9 +34,6 @@ namespace WorkoutTracker.Api.Data
                 entity.Property(e => e.UserId)
                     .IsRequired();
 
-                entity.Property(e => e.DifficultyRating)
-                    .HasConversion<string>();
-
                 entity.HasMany(e => e.PerformedExercises)
                     .WithOne(e => e.TrainingSession)
                     .HasForeignKey(e => e.TrainingSessionId)
@@ -45,7 +42,7 @@ namespace WorkoutTracker.Api.Data
 
             modelBuilder.Entity<PerformedExercise>(entity =>
             {
-                entity.Property(e => e.OrderInSession)
+                entity.Property(e => e.OrderInSession)i
                     .IsRequired();
 
                 entity.HasOne(e => e.ExerciseDefinition)
@@ -74,16 +71,6 @@ namespace WorkoutTracker.Api.Data
 
                 entity.Property(e => e.Description)
                     .IsRequired();
-
-                entity.Property(e => e.ExerciseType)
-                      .HasConversion<string>(); 
-
-                entity.Property(e => e.Equipment)
-                      .HasConversion<string>(); 
-
-                entity.Property(e => e.DifficultyLevel)
-                      .HasConversion<string>();
-
             });
 
             modelBuilder.Entity<ExerciseMuscleGroupLink>(entity =>
@@ -94,9 +81,6 @@ namespace WorkoutTracker.Api.Data
                 entity.HasOne(e => e.ExerciseDefinition)
                     .WithMany(e => e.MuscleGroupsLinks)
                     .HasForeignKey(e => e.ExerciseDefinitionId);
-
-                entity.Property(e => e.MuscleGroup)
-                    .HasConversion<string>();
             });
         }
     }

--- a/src/WorkoutTracker.Api/Services/ExerciseDefinitions/ExerciseDefinitionsService.cs
+++ b/src/WorkoutTracker.Api/Services/ExerciseDefinitions/ExerciseDefinitionsService.cs
@@ -161,13 +161,19 @@ namespace WorkoutTracker.Api.Services.ExerciseDefinitions
                 switch (queryParams.SortBy)
                 {
                     case "name":
-                        query = isDescending ? query.OrderByDescending(t => t.Name) : query.OrderBy(t => t.Name);
+                        query = isDescending 
+                            ? query.OrderByDescending(e => e.Name).ThenByDescending(e => e.Id)
+                            : query.OrderBy(e => e.Name).ThenBy(e => e.Id);
                         break;
                     case "difficulty":
-                        query = isDescending ? query.OrderByDescending(t => t.DifficultyLevel) : query.OrderBy(t => t.DifficultyLevel);
+                        query = isDescending 
+                            ? query.OrderByDescending(e => e.DifficultyLevel).ThenByDescending(e => e.Id)
+                            : query.OrderBy(e => e.DifficultyLevel).ThenBy(e => e.Id);
                         break;
                     default:
-                        query = isDescending ? query.OrderByDescending(t => t.Name) : query.OrderBy(t => t.Name);
+                        query = isDescending
+                            ? query.OrderByDescending(e => e.Id)
+                            : query.OrderBy(e => e.Id);
                         break;
                 }
             }

--- a/tests/WorkoutTracker.Tests/ApiTests/Services/ExerciseDefinitionsService/ExerciseDefinitionsServiceTestsBase.cs
+++ b/tests/WorkoutTracker.Tests/ApiTests/Services/ExerciseDefinitionsService/ExerciseDefinitionsServiceTestsBase.cs
@@ -1,0 +1,49 @@
+﻿using AutoMapper;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using WorkoutTracker.Api.Data;
+using WorkoutTracker.Api.Mapping;
+using WorkoutTracker.Api.Services.ExerciseDefinitions;
+using WorkoutTracker.Tests.Builders;
+
+namespace WorkoutTracker.Tests.ApiTests.Services
+{
+    public abstract class ExerciseDefinitionsServiceTestsBase
+    {
+        private readonly SqliteConnection _connection;
+
+        protected readonly ApplicationDbContext Context;
+        protected readonly IMapper Mapper;
+        protected readonly ExerciseDefinitionsService Service; 
+
+        protected ExerciseDefinitionsServiceTestsBase()
+        {
+            // SQLite in-memory setup
+            _connection = new SqliteConnection("Filename=:memory:");
+            _connection.Open();
+
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseSqlite(_connection)
+                .Options;
+
+            Context = new ApplicationDbContext(options);
+            Context.Database.EnsureCreated();
+
+
+            // AutoMapper configuration 
+            var config = new MapperConfiguration(cfg => cfg.AddProfile(new MappingProfile()));
+            Mapper = config.CreateMapper();
+
+            Service = new ExerciseDefinitionsService(Context, Mapper);
+        }
+
+        protected void SeedDatabaseWithDefaults()
+        {
+            Context.ExerciseDefinitions.RemoveRange(Context.ExerciseDefinitions);
+            Context.SaveChanges();
+
+            Context.ExerciseDefinitions.AddRange(new ExerciseDefinitionBuilder().BuildManyDomains(25));
+            Context.SaveChanges();
+        }
+    }
+}

--- a/tests/WorkoutTracker.Tests/ApiTests/Services/ExerciseDefinitionsService/GetExerciseAsyncTests.cs
+++ b/tests/WorkoutTracker.Tests/ApiTests/Services/ExerciseDefinitionsService/GetExerciseAsyncTests.cs
@@ -1,45 +1,11 @@
-﻿using AutoMapper;
-using FluentAssertions;
-using Microsoft.EntityFrameworkCore;
-using WorkoutTracker.Api.Data;
+﻿using FluentAssertions;
 using WorkoutTracker.Api.DTOs.ExerciseDefinition;
 using WorkoutTracker.Api.Exceptions;
-using WorkoutTracker.Api.Mapping;
-using WorkoutTracker.Api.Services.ExerciseDefinitions;
-using WorkoutTracker.Tests.Builders;
 
 namespace WorkoutTracker.Tests.ApiTests.Services
 {
-    public class GetExerciseAsyncTests
+    public class GetExerciseAsyncTests : ExerciseDefinitionsServiceTestsBase
     {
-        private readonly ApplicationDbContext _context;
-        private readonly IMapper _mapper;
-        private readonly IExerciseDefinitionsService _service;
-
-        public GetExerciseAsyncTests()
-        {
-            // In-memory database configuration
-            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-                .Options;
-            _context = new ApplicationDbContext(options);
-
-            // AutoMapper configuration 
-            var config = new MapperConfiguration(cfg => cfg.AddProfile(new MappingProfile()));
-            _mapper = config.CreateMapper();
-
-            _service = new ExerciseDefinitionsService(_context, _mapper);
-        }
-
-        private void SeedDatabaseWithDefaults()
-        {
-            _context.Database.EnsureDeleted();
-            _context.Database.EnsureCreated();
-
-            _context.ExerciseDefinitions.AddRange(new ExerciseDefinitionBuilder().BuildManyDomains(25));
-            _context.SaveChanges();
-        }
-
         [Fact]
         public async Task GetExerciseAsync_ReturnsExerciseDto()
         {
@@ -48,7 +14,7 @@ namespace WorkoutTracker.Tests.ApiTests.Services
             SeedDatabaseWithDefaults();
 
             // Act 
-            var exercise = await _service.GetExerciseAsync(id);
+            var exercise = await Service.GetExerciseAsync(id);
 
             // Assert
             exercise.Should().BeOfType<ExerciseDefinitionReadDto>();
@@ -64,7 +30,7 @@ namespace WorkoutTracker.Tests.ApiTests.Services
             SeedDatabaseWithDefaults();
 
             // Act 
-            Func<Task> act = async () => await _service.GetExerciseAsync(notExistingId);
+            Func<Task> act = async () => await Service.GetExerciseAsync(notExistingId);
 
             // Assert
             await act.Should().ThrowAsync<EntityNotFoundException>()

--- a/tests/WorkoutTracker.Tests/ApiTests/Services/ExerciseDefinitionsService/GetExercisesAsyncTests.cs
+++ b/tests/WorkoutTracker.Tests/ApiTests/Services/ExerciseDefinitionsService/GetExercisesAsyncTests.cs
@@ -1,46 +1,13 @@
-﻿using AutoMapper;
-using FluentAssertions;
-using Microsoft.EntityFrameworkCore;
-using WorkoutTracker.Api.Data;
+﻿using FluentAssertions;
 using WorkoutTracker.Api.DTOs.ExerciseDefinition;
-using WorkoutTracker.Api.Mapping;
 using WorkoutTracker.Api.Models;
-using WorkoutTracker.Api.Services.ExerciseDefinitions;
 using WorkoutTracker.Api.Utilities;
 using WorkoutTracker.Tests.Builders;
 
 namespace WorkoutTracker.Tests.ApiTests.Services
 {
-    public class GetExercisesAsyncTests
+    public class GetExercisesAsyncTests : ExerciseDefinitionsServiceTestsBase
     {
-        private readonly ApplicationDbContext _context;
-        private readonly IMapper _mapper;
-        private readonly IExerciseDefinitionsService _service;
-
-        public GetExercisesAsyncTests()
-        {
-            // In-memory database configuration
-            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-                .Options;
-            _context = new ApplicationDbContext(options);
-
-            // AutoMapper configuration 
-            var config = new MapperConfiguration(cfg => cfg.AddProfile(new MappingProfile()));
-            _mapper = config.CreateMapper();
-
-            _service = new ExerciseDefinitionsService(_context, _mapper);
-        }
-
-        private void SeedDatabaseWithDefaults()
-        {
-            _context.Database.EnsureDeleted();
-            _context.Database.EnsureCreated();
-
-            _context.ExerciseDefinitions.AddRange(new ExerciseDefinitionBuilder().BuildManyDomains(25));
-            _context.SaveChanges();
-        }
-
         [Fact]
         public async Task GetExercisesAsync_ReturnsPaginatedList()
         {
@@ -51,7 +18,7 @@ namespace WorkoutTracker.Tests.ApiTests.Services
             SeedDatabaseWithDefaults();
 
             // Act
-            var exercises = await _service.GetExercisesAsync(queryParams);
+            var exercises = await Service.GetExercisesAsync(queryParams);
 
             // Assert
             exercises.Should().BeOfType<PaginatedList<ExerciseDefinitionReadDto>>();
@@ -72,12 +39,12 @@ namespace WorkoutTracker.Tests.ApiTests.Services
             };
 
             // Seeding database with 1 object with target value and another with other value
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(expectedDifficultyLevel).BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Intermediate).BuildDomain());
-            _context.SaveChanges();
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(expectedDifficultyLevel).BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Intermediate).BuildDomain());
+            Context.SaveChanges();
 
             // Act
-            var exercises = await _service.GetExercisesAsync(queryParams);
+            var exercises = await Service.GetExercisesAsync(queryParams);
 
             // Assert
             exercises.Should().HaveCount(1);
@@ -97,12 +64,12 @@ namespace WorkoutTracker.Tests.ApiTests.Services
             };
 
             // Seeding database with 1 object with target value and another with other value
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithExerciseType(expectedExerciseType).BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithExerciseType(ExerciseType.Strength).BuildDomain());
-            _context.SaveChanges();
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithExerciseType(expectedExerciseType).BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithExerciseType(ExerciseType.Strength).BuildDomain());
+            Context.SaveChanges();
 
             // Act
-            var exercises = await _service.GetExercisesAsync(queryParams);
+            var exercises = await Service.GetExercisesAsync(queryParams);
 
             // Assert
             exercises.Should().HaveCount(1);
@@ -122,12 +89,12 @@ namespace WorkoutTracker.Tests.ApiTests.Services
             };
 
             // Seeding database with 1 object with target value and another with other value
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName(nameFilter).BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Other name").BuildDomain());
-            _context.SaveChanges();
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName(nameFilter).BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Other name").BuildDomain());
+            Context.SaveChanges();
 
             // Act
-            var exercises = await _service.GetExercisesAsync(queryParams);
+            var exercises = await Service.GetExercisesAsync(queryParams);
 
             // Assert
             exercises.Should().HaveCount(1);
@@ -147,12 +114,12 @@ namespace WorkoutTracker.Tests.ApiTests.Services
             };
 
             // Seeding database with 1 object with target value and another with other value
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithEquipment(expectedEquipment).BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithEquipment(Equipment.Bench).BuildDomain());
-            _context.SaveChanges();
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithEquipment(expectedEquipment).BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithEquipment(Equipment.Bench).BuildDomain());
+            Context.SaveChanges();
 
             // Act
-            var exercises = await _service.GetExercisesAsync(queryParams);
+            var exercises = await Service.GetExercisesAsync(queryParams);
 
             // Assert
             exercises.Should().HaveCount(1);
@@ -172,12 +139,12 @@ namespace WorkoutTracker.Tests.ApiTests.Services
             };
 
             // Seeding database with 1 object with target value and another with other value
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithMuscleGroups(expectedMuscleGroups).BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithMuscleGroups(MuscleGroup.Abs).BuildDomain());
-            _context.SaveChanges();
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithMuscleGroups(expectedMuscleGroups).BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithMuscleGroups(MuscleGroup.Abs).BuildDomain());
+            Context.SaveChanges();
 
             // Act
-            var exercises = await _service.GetExercisesAsync(queryParams);
+            var exercises = await Service.GetExercisesAsync(queryParams);
 
             // Assert
             var exercise = exercises.Should().ContainSingle().Subject;
@@ -197,12 +164,12 @@ namespace WorkoutTracker.Tests.ApiTests.Services
             };
 
             // Seeding database with a partial matching object and not-at-all matching object 
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithMuscleGroups(MuscleGroup.Triceps).BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithMuscleGroups(MuscleGroup.Abs).BuildDomain());
-            _context.SaveChanges();
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithMuscleGroups(MuscleGroup.Triceps).BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithMuscleGroups(MuscleGroup.Abs).BuildDomain());
+            Context.SaveChanges();
 
             // Act
-            var exercises = await _service.GetExercisesAsync(queryParams);
+            var exercises = await Service.GetExercisesAsync(queryParams);
 
             // Assert
             exercises.Should().BeEmpty();
@@ -220,13 +187,13 @@ namespace WorkoutTracker.Tests.ApiTests.Services
                 SortBy = "name"
             };
 
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Push up").BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Bench press").BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Dead bug").BuildDomain());
-            _context.SaveChanges();
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Push up").BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Bench press").BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Dead bug").BuildDomain());
+            Context.SaveChanges();
 
             // Act
-            var exercises = await _service.GetExercisesAsync(queryParams);
+            var exercises = await Service.GetExercisesAsync(queryParams);
 
             // Assert
             exercises.Should().HaveCountGreaterThan(1);
@@ -245,13 +212,13 @@ namespace WorkoutTracker.Tests.ApiTests.Services
                 SortBy = "name"
             };
 
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Push up").BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Bench press").BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Dead bug").BuildDomain());
-            _context.SaveChanges();
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Push up").BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Bench press").BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithName("Dead bug").BuildDomain());
+            Context.SaveChanges();
 
             // Act
-            var exercises = await _service.GetExercisesAsync(queryParams);
+            var exercises = await Service.GetExercisesAsync(queryParams);
 
             // Assert
             exercises.Should().HaveCountGreaterThan(1);
@@ -270,18 +237,18 @@ namespace WorkoutTracker.Tests.ApiTests.Services
                 SortBy = "difficulty"
             };
 
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Intermediate).BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Beginner).BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Advanced).BuildDomain());
-            _context.SaveChanges();
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Intermediate).BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Beginner).BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Advanced).BuildDomain());
+            Context.SaveChanges();
 
             // Act
-            var exercises = await _service.GetExercisesAsync(queryParams);
+            var exercises = await Service.GetExercisesAsync(queryParams);
 
             // Assert
 
             exercises.Should().HaveCount(3);
-            exercises.Should().BeInAscendingOrder(e => e.DifficultyLevel);
+            exercises.Should().BeInAscendingOrder(e => (int)e.DifficultyLevel);
         }
 
         [Fact]
@@ -296,17 +263,17 @@ namespace WorkoutTracker.Tests.ApiTests.Services
                 SortBy = "difficulty"
             };
 
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Intermediate).BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Beginner).BuildDomain());
-            _context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Advanced).BuildDomain());
-            _context.SaveChanges();
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Intermediate).BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Beginner).BuildDomain());
+            Context.ExerciseDefinitions.Add(new ExerciseDefinitionBuilder().WithDifficultyLevel(DifficultyLevel.Advanced).BuildDomain());
+            Context.SaveChanges();
 
             // Act
-            var exercises = await _service.GetExercisesAsync(queryParams);
+            var exercises = await Service.GetExercisesAsync(queryParams);
 
             // Assert
             exercises.Should().HaveCount(3);
-            exercises.Should().BeInDescendingOrder(e => e.Name);
+            exercises.Should().BeInDescendingOrder(e => (int)e.DifficultyLevel);
         }
     }
 }

--- a/tests/WorkoutTracker.Tests/ApiTests/Services/ExerciseDefinitionsService/PostExerciseAsyncTests.cs
+++ b/tests/WorkoutTracker.Tests/ApiTests/Services/ExerciseDefinitionsService/PostExerciseAsyncTests.cs
@@ -1,0 +1,23 @@
+﻿using FluentAssertions;
+using WorkoutTracker.Api.DTOs.ExerciseDefinition;
+using WorkoutTracker.Tests.Builders;
+
+namespace WorkoutTracker.Tests.ApiTests.Services
+{
+    public class PostExerciseAsyncTests : ExerciseDefinitionsServiceTestsBase
+    {
+        [Fact]
+        public async Task PostExerciseAsync_ReturnsReadDto_WhenSuccess()
+        {
+            // Arrange
+            var exerciseDto = new ExerciseDefinitionBuilder().BuildCreateDto();
+
+            // Act
+            var result = await Service.PostExerciseAsync(exerciseDto);
+
+            // Assert
+            result.Should().BeOfType<ExerciseDefinitionReadDto>();
+            result.Id.Should().NotBe(null);
+        }
+    }
+}

--- a/tests/WorkoutTracker.Tests/ApiTests/Services/ExerciseDefinitionsService/UpdateExerciseAsync.cs
+++ b/tests/WorkoutTracker.Tests/ApiTests/Services/ExerciseDefinitionsService/UpdateExerciseAsync.cs
@@ -1,0 +1,42 @@
+﻿using FluentAssertions;
+using WorkoutTracker.Api.Exceptions;
+using WorkoutTracker.Tests.Builders;
+
+namespace WorkoutTracker.Tests.ApiTests.Services
+{
+    public class UpdateExerciseAsync : ExerciseDefinitionsServiceTestsBase
+    {
+        [Fact]
+        public async Task UpdateExerciseAsync_ThrowsError_WhenIdNotMatches()
+        {
+            // Arrange
+            var exerciseId = 1;
+            var exerciseDto = new ExerciseDefinitionBuilder().WithId(exerciseId).BuildUpdateDto();
+            var errorMessage = "ID of an exercise doesn't match with passed ID";
+
+            // Act
+            exerciseDto.Id = 5;
+            Func<Task> act = async () => await Service.UpdateExerciseAsync(exerciseId, exerciseDto);
+
+            // Assert
+            await act.Should().ThrowAsync<EntityNotFoundException>()
+                .WithMessage(errorMessage);
+        }
+
+        [Fact]
+        public async Task UpdateExerciseAsync_ThrowsError_WhenExerciseNotFound()
+        {
+            // Arrange
+            var notExistingId = 127; 
+            var exerciseDto = new ExerciseDefinitionBuilder().WithId(notExistingId).BuildUpdateDto();
+            var errorMessage = "Exercise with this ID doesn't exist";
+
+            // Act
+            Func<Task> act = async () => await Service.UpdateExerciseAsync(notExistingId, exerciseDto);
+
+            // Assert
+            await act.Should().ThrowAsync<EntityNotFoundException>()
+                .WithMessage(errorMessage);
+        }
+    }
+}


### PR DESCRIPTION
- string converions removed from ApplicationDbContext beacuse it was causing problems with sorting exercises by enums
- added second sorting criteria in SortExercises method to force stable sort
- ExerciseDefinitionsServiceTestsBase class created to handle dependencies setup in ExerciseDefinitionService's tests